### PR TITLE
Allow atoms as values for sensitive string label

### DIFF
--- a/lib/cased/sensitive/string.ex
+++ b/lib/cased/sensitive/string.ex
@@ -15,7 +15,7 @@ defmodule Cased.Sensitive.String do
         }
 
   @type new_opts :: [new_opt()]
-  @type new_opt :: {:label, String.t()}
+  @type new_opt :: {:label, String.t() | atom()}
 
   @doc """
   Create a new `Cased.Sensitive.String` struct.


### PR DESCRIPTION
Addresses Dialyzer analysis when using `Cased.Sensitive.String`.